### PR TITLE
added bold for router active

### DIFF
--- a/src/components/skeletons/HeaderComp.vue
+++ b/src/components/skeletons/HeaderComp.vue
@@ -77,7 +77,7 @@
     opacity: 0.7;
   }
 
-  .router-link-exact-active {
+  .router-link-exact-active, .router-link-active {
     font-weight: bold;
   }
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,7 @@ module.exports = {
       auth: {
         login: '/login'
       },
-      feeds: '/',
+      feeds: '/feeds',
       activityBlogs: {
         list: '/activity-blogs',
         add: '/activity-blogs/add',

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -55,6 +55,10 @@ const router = new Router({
       component: login
     },
     {
+      path: '/',
+      redirect: config.app.pages.feeds
+    },
+    {
       path: config.app.pages.feeds,
       name: 'feeds',
       component: feeds,


### PR DESCRIPTION
added bold for all active route, example if the current route `/announcements/add` , so Announcement on HeaderComp will be bold.

@jonathan016 this means that homepage must be `/feeds` and cannot be `/` because the feeds will be bold everytime if we use only slash `/`. access-list must be updated